### PR TITLE
Fix missing names

### DIFF
--- a/wagtailspace/home/models.py
+++ b/wagtailspace/home/models.py
@@ -245,7 +245,7 @@ class HomePage(Page):
     ]
 
     def get_context(self, request):
-        context = super(Wagtail2018Page, self).get_context(request)
+        context = super(HomePage, self).get_context(request)
         context['attendees'] = Registration.objects.all()
         context['dates'] = EventDate.objects.all()
         return context

--- a/wagtailspace/urls.py
+++ b/wagtailspace/urls.py
@@ -7,7 +7,6 @@ from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
 
 from wagtailspace.home.views import attendees, signup
-from wagtailspace.search import views as search_views
 
 urlpatterns = []
 


### PR DESCRIPTION
This PR just fixes a couple of missing names that prevent the project from running.

- `Wagtail2018Page` is presumably renamed for open sourcing. 
- `wagtailspace.search` is not included in the open source project. This corrects for that.

This is fantastic, thank you for open sourcing!